### PR TITLE
The new line of the keywords list

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "gatsby-transformer-sharp": "^1.6.22",
     "lodash": "^4.17.5"
   },
-  "keywords": ["osaka", "ruby", "rubykaigi"],
+  "keywords": [
+    "osaka",
+    "ruby",
+    "rubykaigi"
+  ],
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
When I clone the repository and run 'npm install', it automatically wrapped a line.

#### environment
```
node: v8.11.1
npm: 5.8.0
```